### PR TITLE
Handle Galaxy deploys with CDN and multiple servers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ const ALLOWED_PROTOCOLS = ['http:', 'https:'];
  */
 function stripSlashes(url){
 	if (url){
-    	return url.replace(/\/$/, "");
+			return url.replace(/\/$/, "");
 	} else {
 		return url;
 	}
@@ -76,29 +76,29 @@ function CdnController(){
 	function setClientCdnUrl(cdnUrl){
 		// Make the CDN_URL available on the client
 		// console.log("Setting BundledJsCssPrefix to "+cdnUrl);
-    var hasQuestionMark = new RegExp('[\?]');
-    WebAppInternals.setBundledJsCssUrlRewriteHook(function(url) {
-      // This code fixes an issue in Galaxy where you can end up getting served
-      // stale code after deployments
-      var galaxyVersionId = process.env.GALAXY_APP_VERSION_ID;
-      var rewrittenUrl = cdnUrl + url;
-      if (galaxyVersionId) {
-        var separator = hasQuestionMark.test(url) ? '&' : '?';
-        rewrittenUrl += separator + 'g_app_v=' + galaxyVersionId;
-      }
-      return rewrittenUrl;
-    });
+		var hasQuestionMark = new RegExp('[\?]');
+		WebAppInternals.setBundledJsCssUrlRewriteHook(function(url) {
+			// This code fixes an issue in Galaxy where you can end up getting served
+			// stale code after deployments
+			var galaxyVersionId = process.env.GALAXY_APP_VERSION_ID;
+			var rewrittenUrl = cdnUrl + url;
+			if (galaxyVersionId) {
+				var separator = hasQuestionMark.test(url) ? '&' : '?';
+				rewrittenUrl += separator + 'g_app_v=' + galaxyVersionId;
+			}
+			return rewrittenUrl;
+		});
 		// WebAppInternals.setBundledJsCssPrefix(cdnUrl);
 		__meteor_runtime_config__.CDN_URL = cdnUrl;
 	}
 
-  function configureBrowserPolicy(cdnUrl){
-    console.log('Attemping to configure BrowserPolicy');
-    if (Package['browser-policy']) {
-      BrowserPolicy.content.allowOriginForAll(cdnUrl);
-      console.log('Configure BrowserPolicy allowOriginForAll(' + cdnUrl + ')');
-    }
-  }
+	function configureBrowserPolicy(cdnUrl){
+		console.log('Attemping to configure BrowserPolicy');
+		if (Package['browser-policy']) {
+			BrowserPolicy.content.allowOriginForAll(cdnUrl);
+			console.log('Configure BrowserPolicy allowOriginForAll(' + cdnUrl + ')');
+		}
+	}
 
 
 	function CORSconnectHandler(req, res, next){
@@ -145,7 +145,7 @@ function CdnController(){
 	// Initialize the CDN
 	if (validateSettings(cdnUrl,rootUrl)){
 		setClientCdnUrl(cdnUrl);
-    configureBrowserPolicy(cdnUrl);
+		configureBrowserPolicy(cdnUrl);
 		WebApp.rawConnectHandlers.use(static404connectHandler);
 		WebApp.rawConnectHandlers.use(CORSconnectHandler);
 		console.info('Using CDN: '+cdnUrl);
@@ -162,5 +162,5 @@ function CdnController(){
 // Export the CDN object
 CDN = {};
 Meteor.startup(function() {
-  CDN = new CdnController();
+	CDN = new CdnController();
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -76,7 +76,19 @@ function CdnController(){
 	function setClientCdnUrl(cdnUrl){
 		// Make the CDN_URL available on the client
 		// console.log("Setting BundledJsCssPrefix to "+cdnUrl);
-		WebAppInternals.setBundledJsCssPrefix(cdnUrl);
+    var hasQuestionMark = new RegExp('[\?]');
+    WebAppInternals.setBundledJsCssUrlRewriteHook(function(url) {
+      // This code fixes an issue in Galaxy where you can end up getting served
+      // stale code after deployments
+      var galaxyVersionId = process.env.GALAXY_APP_VERSION_ID;
+      var rewrittenUrl = cdnUrl + url;
+      if (galaxyVersionId) {
+        var separator = hasQuestionMark.test(url) ? '&' : '?';
+        rewrittenUrl += separator + 'g_app_v=' + galaxyVersionId;
+      }
+      return rewrittenUrl;
+    });
+		// WebAppInternals.setBundledJsCssPrefix(cdnUrl);
 		__meteor_runtime_config__.CDN_URL = cdnUrl;
 	}
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'nitrolabs:cdn',
-  version: '1.2.5',
+  version: '1.2.6',
   summary: 'Serve Meteor content from a CDN',
   git: 'https://github.com/nitrolabs/meteor-cdn',
   documentation: 'README.md'


### PR DESCRIPTION
Right now if you deploy with a CDN on Galaxy with multiple servers, the CDN can get routed to an old version in the galaxy router and thus get 404s for 5-10 minutes after deployment.  This fixes that.  If the Galaxy environment variable isn't found, it just falls back to existing behavior