### PR TITLE
Adds CDN.get_cdn_url() method available for client & server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ evaluate helpers in the head block.
 </template>
 ```
 
+### Getting CDN url in Javascript
+CDN exposes function which can be used to get current CDN address.
+
+```javascript
+CDN.get_cdn_url()
+```
+
 ### Webfont headers
 Google Chrome and several other mainstream browsers prevent webfonts being loaded from via CORS, unless the [Strict-Transport-Security  header](https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security) is set correctly. This package automatically adds the correct CORS and STS headers to webfont files to prevent this issue. When setting up Cloudfront or CloudFlare you should whitelist the Host and Strict-Transport-Security header.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -82,3 +82,10 @@ function pathJoin(parts){
   }).join("/");
 }
 
+// Export the CDN object
+CDN = {};
+
+// Add CDN_URL available through the CDN object
+CDN.get_cdn_url = function(){
+  return __meteor_runtime_config__.CDN_URL || "";
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -162,6 +162,11 @@ function CdnController(){
 // Export the CDN object
 CDN = {};
 
+// Add CDN_URL available through the CDN object
+CDN.get_cdn_url = function(){
+  return __meteor_runtime_config__.CDN_URL || "";
+}
+
 // Add this for testing purposes
 CDN._controllerClass = CdnController;
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'nitrolabs:cdn',
-  version: '1.2.8',
+  version: '1.2.9',
   summary: 'Serve Meteor content from a CDN',
   git: 'https://github.com/nitrolabs/meteor-cdn',
   documentation: 'README.md'
@@ -9,6 +9,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.1.0.2');
   api.export('CDN','server');
+  api.export('CDN','client');
   api.use('webapp','server');
   api.use('templating','client');
   api.use('browser-policy', {weak: true});


### PR DESCRIPTION
This PR adds the **CDN.get_cdn_url()** available for client & server as discussed in [this issue](https://github.com/Nitrolabs/meteor-cdn/issues/4). I've tested this on my local and production environment and all seems to work fine. Didn't have time to figure out how to do the tests for this (if even needed to).

I've also changed the project version to 1.2.9 from 1.2.8.