### PR TITLE
Added headers being able to be passed for CDN.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ CDN.get_cdn_url()
 ### Modifying headers to allow caching of public files
 By default all files in Meteor public folder have `cache-content: public, max-age: 0` header set, which directs the browser / CDN to cache the files for 0 seconds and means that the files are **always** served from the original server and never cached. By setting `CDN.config.headers` you have the ability to set custom headers for files / folders in the public folder to make files in public folder being cached. Path used in `CDN.config.header` can be full path to file or folder which under the files are in.
 
-Below is an example on setting up caching for public folder:
+Below is an example on setting up caching for public folder. Add the configuration to your server, preferably inside your `Meteor.startup` function:
 
 ```javascript
 // Best to only setup caching on production so things do not get cached on development

--- a/README.md
+++ b/README.md
@@ -37,6 +37,33 @@ CDN exposes function which can be used to get current CDN address.
 ```javascript
 CDN.get_cdn_url()
 ```
+### Modifying headers to allow caching of public files
+By default all files in Meteor public folder have `cache-content: public, max-age: 0` header set, which directs the browser / CDN to cache the files for 0 seconds and means that the files are **always** served from the original server and never cached. By setting `CDN.config.headers` you have the ability to set custom headers for files / folders in the public folder to make files in public folder being cached. Path used in `CDN.config.header` can be full path to file or folder which under the files are in.
+
+Below is an example on setting up caching for public folder:
+
+```javascript
+// Best to only setup caching on production so things do not get cached on development
+if (Meteor.isProduction) {
+    CDN.config({
+        headers: {
+            // Files in this example folder change very infrequently
+            "/someicons/": { "cache-control": "public, max-age: 10000" },
+            // We can set smaller caching times for individual files
+            "/someicons/changingIcon.png": { "cache-control": "public, max-age: 100" },
+            // This folder contains subfolders and files under them
+            "/staticassets/": { "cache-control": "public, max-age: 5000" },
+        };
+    });
+}
+```
+
+To verify that the headers we're being set correctly for your assets, you can:
+- Open **Chrome Developer Tools**
+- Open **Network** tab
+- Make sure the topleft recording balloon is set to record
+- Refresh page
+- Select assets you set the headers for and verify that the **Response Headers** section shows correct headers (remember to remove the production check if trying to check the headers on development environment).
 
 ### Webfont headers
 Google Chrome and several other mainstream browsers prevent webfonts being loaded from via CORS, unless the [Strict-Transport-Security  header](https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security) is set correctly. This package automatically adds the correct CORS and STS headers to webfont files to prevent this issue. When setting up Cloudfront or CloudFlare you should whitelist the Host and Strict-Transport-Security header.

--- a/lib/server.js
+++ b/lib/server.js
@@ -113,7 +113,6 @@ function CdnController(){
 	}
 
 
-
 	function static404connectHandler(req, res, next){
 		// Return 404 if a non-existent static file is requested
 		// If REQUEST_HOST === CDN_URL then a 404 is returned for all non-static files
@@ -165,6 +164,30 @@ CDN = {};
 // Add CDN_URL available through the CDN object
 CDN.get_cdn_url = function(){
   return __meteor_runtime_config__.CDN_URL || "";
+}
+
+// Create CDN config object.
+// Config object can include the headers object inside which can be used to
+// override headers for certain folders or files.
+CDN.config = function(config) {
+	if (config.headers) {
+		WebApp.rawConnectHandlers.use("/", function(req, res, next) {
+			for (var path in config.headers) {
+				if (config.headers.hasOwnProperty(path)) {
+					// If path matches, setup headers for the response
+					if (req._parsedUrl.path.startsWith(path)) {
+						for (var pathHeaders in config.headers[path]) {
+							if (config.headers[path].hasOwnProperty(pathHeaders)) {
+								//console.log("Setting header: " + pathHeaders + ": " + config.headers[path][pathHeaders] + " for path: " + req._parsedUrl.path);
+								res.setHeader(pathHeaders, config.headers[path][pathHeaders]);
+							}
+						}
+					}
+				}
+			}
+			next();
+		});
+	}
 }
 
 // Add this for testing purposes

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'nitrolabs:cdn',
-  version: '1.2.9',
+  version: '1.2.10',
   summary: 'Serve Meteor content from a CDN',
   git: 'https://github.com/nitrolabs/meteor-cdn',
   documentation: 'README.md'


### PR DESCRIPTION
Implements issue [6 Ability to change cache-headers max-age for files in public folder](https://github.com/Nitrolabs/meteor-cdn/issues/6). This allows initialization like this in the server to allow customizing headers for certain files or folders in the public folder:
```javascript
CDN.config({
    headers: {
        // Files in this example folder change very infrequently
        "/someicons/": { "cache-control": "public, max-age: 10000" },
        // We can set smaller caching times for individual files
        "/someicons/changingIcon.png": { "cache-control": "public, max-age: 100" },
        // This folder contains subfolders and files under them
        "/staticassets/": { "cache-control": "public, max-age: 5000" },
    };
});
```

I've tested this both on local environment and on production. I've added section in readme file on how to use this. I've also changed the extension version to higher one.