### PR TITLE
fix order of parameters passed to validateSettings

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -142,7 +142,7 @@ function CdnController(){
 
 
 	// Initialize the CDN
-	if (validateSettings(cdnUrl,rootUrl)){
+	if (validateSettings(rootUrl, cdnUrl)){
 		setClientCdnUrl(cdnUrl);
 		configureBrowserPolicy(cdnUrl);
 		WebApp.rawConnectHandlers.use(static404connectHandler);


### PR DESCRIPTION
The validateSettings function expects params to be passed as `rootUrl, cdnUrl`. Passing in these params in the wrong order can lead to confusing validation error messages.