### PR TITLE
Don't use es6 syntax

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -17,7 +17,7 @@
  * 2) Re-establishing websocket connection after it is dropped (/sock/js call)
  *
  */
-const STATIC = ['.css','.js'];
+var STATIC = ['.css','.js'];
 
 
 


### PR DESCRIPTION
The es6 code used isn't transpiled and failes IE < 11 