### PR TITLE
fix: Cannot use 'in' operator to search for undefined

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -125,10 +125,11 @@ function CdnController(){
 
 		// Cloudfront removes all headers by default
 		// We need the HOST header to determine where this request came from
+    var clientArch = Meteor.isCordova ? "web.cordova" : Meteor.isModern ? "web.browser" : "web.browser.legacy"
 		if (!req.headers.host) {
 			console.warn('HOST header is not set');
 			console.warn('Unable to determine if this request came via the CDN');
-		} else if (isFromCDN && !(pathname in WebAppInternals.staticFiles)){
+		} else if (isFromCDN && !(pathname in WebAppInternals.staticFilesByArch[clientArch])){
 			console.warn("Static resource not found: "+pathname);
 			res.writeHead(404);
 			res.write('Static File Not Found');


### PR DESCRIPTION
It appear the static files are groupped by arch:
https://github.com/meteor/meteor/blob/master/packages/webapp/webapp_server.js#L643